### PR TITLE
Processing of http-post requests body

### DIFF
--- a/src/request_parsers/http.php
+++ b/src/request_parsers/http.php
@@ -186,15 +186,17 @@ class ezcMvcHttpRequestParser extends ezcMvcRequestParser
     }
 
     /**
-     * Processes the request body for PUT requests.
+     * Processes the request body for PUT and POST requests.
      */
     protected function processBody()
     {
         $req = $this->request;
 
-        if ( $req->protocol == 'http-put' )
+        switch ( $req->protocol )
         {
-            $req->body = file_get_contents( "php://input" );
+            case 'http-put':
+            case 'http-post':
+                $req->body = file_get_contents( "php://input" );
         }
     }
 


### PR DESCRIPTION
When I tried to implement a PubSubHubBub subscriber, I noticed that I was not able to get Atom notifications from hubs because it was provided as a POST request body : 

> "A content distribution request is an HTTP [RFC2616] POST request from hub to the subscriber's callback URL with the list of new and changed entries. This request MUST have a Content-Type of application/atom+xml when the request body is an Atom [RFC4287] feed document, or a Content-Type of application/rss+xml when the request body is an RSS [RSS20] feed document."
> ([PubSubHubbub Core 0.3 -- Working Draft : Content Distribution](http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.3.html#contentdistribution))

I corrected it for my own needs, but if it could help someone... Feel free to merge or comment.
